### PR TITLE
Add annotation IDs and map pages to canvases

### DIFF
--- a/annotations/dates/dates.11ty.js
+++ b/annotations/dates/dates.11ty.js
@@ -1,19 +1,17 @@
-const PAGE_SIZE = 100
-
 module.exports = class DatesPage {
   data() {
     return {
       pagination: {
-        data: 'dates',
-        size: PAGE_SIZE
+        data: 'manifest.sequences[0].canvases',
+        size: 1
       },
       permalink: ctx => `/annotations/dates/${ctx.pagination.pageNumber}.json`
     }
   }
 
   render({ annotations, pagination }) {
-    const start = pagination.pageNumber * PAGE_SIZE
-    const finish = start + PAGE_SIZE
+    const [canvas] = pagination.items
+    const items = annotations.filter(annotation => annotation.target.startsWith(canvas['@id']))
     const page = {
       '@context': 'http://iiif.io/api/presentation/3/context.json',
       id: `https://zooniverse.github.io/iiif-annotations/annotations/dates/${pagination.pageNumber}.json`,
@@ -22,7 +20,7 @@ module.exports = class DatesPage {
         id: 'https://zooniverse.github.io/iiif-annotations/annotations/dates.json',
         type: "AnnotationCollection"
       },
-      items: annotations.slice(start, finish)
+      items
     }
     const { href } = pagination
     if (href.previous) {

--- a/annotations/dates/dates.11tydata.js
+++ b/annotations/dates/dates.11tydata.js
@@ -13,14 +13,18 @@ function transformTextTasks(annotations, canvas) {
   }
 }
 
-function annotations({ manifest, dates }) {
-  return dates.map(classification => {
+function annotations({ manifest, dates: classifications }) {
+  const dates = classifications.map(classification => {
     const { metadata, annotations, subjectMetadata } = classification
     const canvasIndex = subjectMetadata['#priority'] - 1
     const [ sequence ] = manifest.sequences
     const canvas = sequence.canvases[canvasIndex]
     return transformTextTasks(annotations, canvas)
   })
+  dates.forEach((date, index) => {
+    date.id = `https://zooniverse.github.io/iiif-annotations/bldigital/in-the-spotlight/dates/${index}`
+  })
+  return dates
 }
 
 module.exports = {

--- a/annotations/titles/titles.11ty.js
+++ b/annotations/titles/titles.11ty.js
@@ -1,19 +1,17 @@
-const PAGE_SIZE = 100
-
 module.exports = class TitlesPage {
   data() {
     return {
       pagination: {
-        data: 'titles',
-        size: PAGE_SIZE
+        data: 'manifest.sequences[0].canvases',
+        size: 1
       },
       permalink: ctx => `/annotations/titles/${ctx.pagination.pageNumber}.json`
     }
   }
 
   render({ annotations, pagination }) {
-    const start = pagination.pageNumber * PAGE_SIZE
-    const finish = start + PAGE_SIZE
+    const [canvas] = pagination.items
+    const items = annotations.filter(annotation => annotation.target.startsWith(canvas['@id']))
     const page = {
       '@context': 'http://iiif.io/api/presentation/3/context.json',
       id: `https://zooniverse.github.io/iiif-annotations/annotations/titles/${pagination.pageNumber}.json`,
@@ -22,7 +20,7 @@ module.exports = class TitlesPage {
         id: 'https://zooniverse.github.io/iiif-annotations/annotations/titles.json',
         type: "AnnotationCollection"
       },
-      items: annotations.slice(start, finish).flat()
+      items
     }
     const { href } = pagination
     if (href.previous) {

--- a/annotations/titles/titles.11tydata.js
+++ b/annotations/titles/titles.11tydata.js
@@ -28,14 +28,18 @@ function transformRectangles(annotations, canvas, config) {
   })
 }
 
-function annotations({ config, manifest, titles }) {
-  return titles.map(classification => {
+function annotations({ config, manifest, titles: classifications }) {
+  const titles = classifications.map(classification => {
     const { metadata, annotations, subjectMetadata } = classification
     const canvasIndex = subjectMetadata['#priority'] - 1
     const [ sequence ] = manifest.sequences
     const canvas = sequence.canvases[canvasIndex]
     return transformRectangles(annotations, canvas, config)
+  }).flat()
+  titles.forEach((title, index) => {
+    title.id = `https://zooniverse.github.io/iiif-annotations/bldigital/in-the-spotlight/titles/${index}`
   })
+  return titles
 }
 
 module.exports = {


### PR DESCRIPTION
- Publish one `AnnotationPage` for each input canvas.
- Assign a HTTPS ID to each date and title annotation.

Closes #3.
Closes #4.
