### PR TITLE
Add partOf to annotation targets

### DIFF
--- a/annotations/dates/dates.11ty.js
+++ b/annotations/dates/dates.11ty.js
@@ -11,7 +11,7 @@ module.exports = class DatesPage {
 
   render({ annotations, pagination }) {
     const [canvas] = pagination.items
-    const items = annotations.filter(annotation => annotation.target.startsWith(canvas['@id']))
+    const items = annotations.filter(annotation => annotation.target.source.id === canvas['@id'])
     const page = {
       '@context': 'http://iiif.io/api/presentation/3/context.json',
       id: `https://zooniverse.github.io/iiif-annotations/annotations/dates/${pagination.pageNumber}.json`,

--- a/annotations/dates/dates.11tydata.js
+++ b/annotations/dates/dates.11tydata.js
@@ -1,5 +1,10 @@
-function transformTextTasks(annotations, canvas) {
+function transformTextTasks(annotations, canvas, partOf) {
   const text = annotations.find(annotation => annotation.task === 'T0')
+  const source = {
+    id: canvas['@id'],
+    type: 'Canvas',
+    partOf
+  }
   return {
     type: 'Annotation',
     motivation: 'tagging',
@@ -9,17 +14,23 @@ function transformTextTasks(annotations, canvas) {
       language: 'en',
       format: 'text/plain'
     },
-    target: canvas['@id']
+    target: {
+      source
+    }
   }
 }
 
 function annotations({ manifest, dates: classifications }) {
+  const partOf = {
+    id: manifest[`@id`],
+    type: 'Manifest'
+  }
   const dates = classifications.map(classification => {
     const { metadata, annotations, subjectMetadata } = classification
     const canvasIndex = subjectMetadata['#priority'] - 1
     const [ sequence ] = manifest.sequences
     const canvas = sequence.canvases[canvasIndex]
-    return transformTextTasks(annotations, canvas)
+    return transformTextTasks(annotations, canvas, partOf)
   })
   dates.forEach((date, index) => {
     date.id = `https://zooniverse.github.io/iiif-annotations/bldigital/in-the-spotlight/dates/${index}`

--- a/annotations/titles/titles.11ty.js
+++ b/annotations/titles/titles.11ty.js
@@ -11,7 +11,7 @@ module.exports = class TitlesPage {
 
   render({ annotations, pagination }) {
     const [canvas] = pagination.items
-    const items = annotations.filter(annotation => annotation.target.startsWith(canvas['@id']))
+    const items = annotations.filter(annotation => annotation.target.source.id === canvas['@id'])
     const page = {
       '@context': 'http://iiif.io/api/presentation/3/context.json',
       id: `https://zooniverse.github.io/iiif-annotations/annotations/titles/${pagination.pageNumber}.json`,

--- a/annotations/titles/titles.11tydata.js
+++ b/annotations/titles/titles.11tydata.js
@@ -7,11 +7,21 @@ function scaledRectangle(rectangle, canvas, { imageHeight, imageWidth }) {
   const h = parseInt(height * scale, 10)
   return { x, y, w, h }
 }
-function transformRectangles(annotations, canvas, config) {
+function transformRectangles(annotations, canvas, config, partOf) {
   const drawing = annotations.find(annotation => annotation.task === 'T0')
   const rectangles = drawing.value
+  const source = {
+    id: canvas['@id'],
+    type: 'Canvas',
+    partOf
+  }
   return rectangles.map((rectangle, index) => {
     const { x, y, w, h } = scaledRectangle(rectangle, canvas, config)
+    const selector = {
+      type: 'FragmentSelector',
+      conformsTo: 'http://www.w3.org/TR/media-frags/',
+      value: `xywh=${x},${y},${w},${h}`
+    }
     const textAnnotation = annotations.find(annotation => annotation.markIndex === index)
     const label = textAnnotation.value
     return {
@@ -23,18 +33,25 @@ function transformRectangles(annotations, canvas, config) {
         language: 'en',
         format: 'text/plain'
       },
-      target: `${canvas['@id']}#xywh=${x},${y},${w},${h}`
+      target: {
+        source,
+        selector
+      }
     }
   })
 }
 
 function annotations({ config, manifest, titles: classifications }) {
+  const partOf = {
+    id: manifest[`@id`],
+    type: 'Manifest'
+  }
   const titles = classifications.map(classification => {
     const { metadata, annotations, subjectMetadata } = classification
     const canvasIndex = subjectMetadata['#priority'] - 1
     const [ sequence ] = manifest.sequences
     const canvas = sequence.canvases[canvasIndex]
-    return transformRectangles(annotations, canvas, config)
+    return transformRectangles(annotations, canvas, config, partOf)
   }).flat()
   titles.forEach((title, index) => {
     title.id = `https://zooniverse.github.io/iiif-annotations/bldigital/in-the-spotlight/titles/${index}`


### PR DESCRIPTION
Write annotation targets as objects, including `partOf` pointing to the annotated manifest.

Closes #5.